### PR TITLE
Fixed clone in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Comet3DS was created by the main devs with one thing in mind -- being more accep
 
 ## Compiling
 
-First you need to clone the repository with: `git clone https://github.com/AuroraWright/Luma3DS.git`  
+First you need to clone the repository with: `git clone https://github.com/6100m/Comet3DS.git`  
 To compile, you'll need [armips](https://github.com/Kingcom/armips) and a build of a recent commit of [makerom](https://github.com/profi200/Project_CTR) added to your PATH. You'll also need to install [firmtool](https://github.com/TuxSH/firmtool), its README contains installation instructions.
 You'll also need to update your [libctru](https://github.com/smealum/ctrulib) install, building from the latest commit.  
 Here are [Windows](https://buildbot.orphis.net/armips/) and [Linux](https://mega.nz/#!uQ1T1IAD!Q91O0e12LXKiaXh_YjXD3D5m8_W3FuMI-hEa6KVMRDQ) builds of armips (thanks to who compiled them!) and [makerom](https://github.com/Steveice10/buildtools/tree/master/3ds) (thanks @Steveice10!).   


### PR DESCRIPTION
This is a small fix in the Readme that changes the git clone command to clone from this repo and no Luma3DS

Anything below this is not actually part of the pull request and rather a message to 6100m, the maintainer of this fork:

Hikari-chin was never directly mean to you and just tried to ensure a certain level of quality the code in Luma3DS and to make sure features actually have a reason to be in there.
For example being able to install a CIA over Rosalina sure is nice... but why replace FBI when FBI is better at it.

Luma3DS has been a Project many people have been working on as its been the leading 3DS custom firmware at this point
and people have been trying to add their code to it.
Look at Nanquitas for example.
Nanquitas has made a bunch of pull request in which he tried fixing something that he either though was  bug or adding something that would improve Luma.
Lets take [#1012](https://github.com/AuroraWright/Luma3DS/pull/1012) for example it fixes the freeze encountered when Rosalina is opened before system start.
This improves Luma and is not a useless feature.

Now look at [#1007](https://github.com/AuroraWright/Luma3DS/pull/1007).
Nanquitas thinks there is is a error in the code and suggest a fix and gets told that it was indeed right and accepts that closing the PR


Anyhow have fun with this fork

Not to be insulting but you seem to have basic knowledge of how to user a git repository